### PR TITLE
Get_data function sub-optimality (issue #33).

### DIFF
--- a/mario/core/AttrData.py
+++ b/mario/core/AttrData.py
@@ -1506,6 +1506,91 @@ class Database(CoreModel):
             for note in notes:
                 self.meta._add_history(f"User note: {note}")
 
+    def query(
+            self,
+            matrices,
+            scenarios = ["baseline"],
+            base_scenario = None,
+            type="absolute",
+    ):
+        """ Requests a specific data from the database
+
+        Parameters
+        ----------
+        matrices : str
+            list of the matrices to return
+
+        scenarios : str, List[str]
+            list of scenarios for returing the matrices
+
+        base_scenario : str
+            str representing the base scenario in case that the data should be returned for the change in data between scenarios
+
+        type: str
+            #. 'absolute' for absolute difference for scenarios
+            #. 'relative' for relative difference for scenarios
+
+
+        Returns
+        -------
+        dict,pd.DataFrame
+            If multiple scenarios are passed, it returns a dict where keys are the scenarios and vals are the matrices. matrices itself could be a dict or pd.DataFrame depending if multiple matrices or one matrix is passed
+
+            
+        Example
+        -------
+        Let's consider the case that multiple scenarios ['sc.1','sc.2'] and multiple matrices ['X','z'] are passed:
+
+        .. code-block:: python
+
+            output = example.query(scenarios= ['sc.1','sc.2'], matrices = ['X','z'])
+
+        the output in this case would be:
+
+        type: Dict[Dict[pd.DataFrame]]
+
+        {
+            "sc.1" : {
+                "X": pd.DataFrame,
+                "z": pd.DataFrame,
+            },
+            "sc.2" : {
+                "X": pd.DataFrame,
+                "z": pd.DataFrame,
+            },
+            
+        }
+
+        if only one scenario ("sc.1") is passed, output will be:
+        
+        type Dict[pd.DataFrame]
+        {
+            "X": pd.DataFrame,
+            "Y": pd.DataFrame,
+        }
+
+        if only one scenario ("sc.1") and one matrix ("X") is passed the output will be a single pd.DataFrame.
+        """
+        data = self.get_data(
+            matrices=matrices,
+            units=False,
+            indeces=False,
+            format="dict",
+            scenarios=scenarios,
+            base_scenario = base_scenario,
+            type = type
+        )
+
+        
+        if len(matrices) == 1:
+            for scenario in scenarios:
+                data[scenario]= data[scenario][matrices[0]]
+
+        if len(scenarios) == 1:
+            data = data[scenarios[0]]
+
+        return data
+    
     def get_data(
         self,
         matrices,
@@ -1523,7 +1608,7 @@ class Database(CoreModel):
 
         Parameters
         ----------
-        path : str
+        matrices : str
             list of the matrices to return
 
         units : boolean

--- a/mario/test/mario_test.py
+++ b/mario/test/mario_test.py
@@ -50,7 +50,7 @@ s
     """
 
     return parse_from_excel(
-        path=f"{path}/{table}.xlsx", table=table, name=f"{table} test"
+        path=f"{path}/{table}.xlsx", table=table, name=f"{table} test",mode = "flows"
     )
 
 def load_dummy(test):

--- a/tests/test_attrdata.py
+++ b/tests/test_attrdata.py
@@ -40,7 +40,8 @@ def agg_IOT():
 
     data = parse_from_excel(
         path = f"{MOCK_PATH}/IOT_aggregation.xlsx",
-        table = 'IOT'
+        table = 'IOT',
+        mode = "flows"
     )
 
     data.path = f"{MOCK_PATH}/IOT_aggregation.xlsx"
@@ -255,8 +256,60 @@ def test_to_pymrio(CoreDataIOT,CoreDataSUT):
 
 
 
+def test_querry(CoreDataIOT):
+
+    CoreDataIOT.calc_all()
+
+    CoreDataIOT.clone_scenario(scenario= 'baseline', name='sc.2')
 
 
+    # case 1: Nested dict
+    scenarios = ["baseline","sc.2"]
+    matrices=["X","z"]
 
+    case_1 = CoreDataIOT.query(scenarios = scenarios,matrices=matrices)
+
+    assert set(case_1.keys()) == set(scenarios)
+    assert set(list(case_1.values())[0].keys()) == set(matrices)
+
+    for k in  scenarios:
+        for v in matrices:
+            pdt.assert_frame_equal(case_1[k][v],CoreDataIOT[k][v])
+
+
+    # case 2: one scenario and 2 matrices
+    scenarios = ["sc.2"]
+    matrices=["X","z"]
+
+    case_2 = CoreDataIOT.query(scenarios = scenarios,matrices=matrices)
+
+    assert set(case_2.keys()) == set(matrices)
+
+
+    for v in matrices:
+        pdt.assert_frame_equal(case_2[v],CoreDataIOT[scenarios[0]][v])
+
+
+    # case 3: two scenarios and 1 matrix
+    scenarios = ["baseline","sc.2"]
+    matrices=["X"]
+
+    case_3 = CoreDataIOT.query(scenarios = scenarios,matrices=matrices)
+
+    assert set(case_3.keys()) == set(scenarios)
     
 
+
+    for k in scenarios:
+        pdt.assert_frame_equal(case_3[k],CoreDataIOT[k][matrices[0]])
+
+
+    # case 4: one scneario and one matrix
+    scenarios = ["sc.2"]
+    matrices=["X"]
+
+    case_4 = CoreDataIOT.query(scenarios = scenarios,matrices=matrices)
+
+    assert isinstance(case_4,pd.DataFrame)
+
+    pdt.assert_frame_equal(case_4,CoreDataIOT[scenarios[0]][matrices[0]])


### PR DESCRIPTION
Issue:
The get_data function was supposed to be used as a back-hand. Probabily for this reason, it looks sub-optimal and may be improved. Best way to use it to extract a specific matrix (e.g. f) of the main object (world) is:

world.get_data(matrices=['f'], scenarios=['scenario 2'])['scenario 2'][0]

The function may be improved by avoiding the pass the same info twice. Furthermore, a dedicated documentation should be added.

Solution:
the best way to solve the problem would be to have a new function with a more user-friendy function that executes the get_data function in a simpler and more intuitive way and leave the get_data function as a private function that is extensively used in the backend. Probably changing this function itself will arise backward-compatibility issues.

A new function called "query" is added to relax the abovementioned issues.

Changes:
1. AttrData.py query function --> with docs

2. test_attrdata.py test_query --> function unit test

3. minor changes for mario_test, load_test function to make it compatible with recent changes of make the mode as a non-default value in excel parser function.