### PR TITLE
Plot linkages fix issue  #43

### DIFF
--- a/mario/tools/iomath.py
+++ b/mario/tools/iomath.py
@@ -510,11 +510,11 @@ def linkages_calculation(cut_diag, matrices, multi_mode, normalized):
             )
 
             links.loc[index, ("Total Backward", "Local")] = (
-                matrices["w"].loc[index, index[0]].sum().sum()
+                matrices["w"].T.loc[index, index[0]].sum().sum()
             )
             links.loc[index, ("Total Backward", "Foreign")] = (
-                matrices["w"].loc[index].sum().sum()
-                - matrices["w"].loc[index, index[0]].sum().sum()
+                matrices["w"].T.loc[index].sum().sum()
+                - matrices["w"].T.loc[index, index[0]].sum().sum()
             )
 
             links.loc[index, ("Direct Forward", "Local")] = (
@@ -526,11 +526,11 @@ def linkages_calculation(cut_diag, matrices, multi_mode, normalized):
             )
 
             links.loc[index, ("Direct Backward", "Local")] = (
-                matrices["z"].loc[index, index[0]].sum().sum()
+                matrices["z"].T.loc[index, index[0]].sum().sum()
             )
             links.loc[index, ("Direct Backward", "Foreign")] = (
-                matrices["z"].loc[index].sum().sum()
-                - matrices["z"].loc[index, index[0]].sum().sum()
+                matrices["z"].T.loc[index].sum().sum()
+                - matrices["z"].T.loc[index, index[0]].sum().sum()
             )
 
         if normalized:

--- a/mario/tools/plots.py
+++ b/mario/tools/plots.py
@@ -103,7 +103,7 @@ def _plot_linkages(
         ] = f"Sectors classification according to {plot} Backward and Forward linkages"
         layout[
             "legend_title_text"
-        ] = "Regions<br><i>Local contribution is luminous<br>Foreign contribution is opaque"
+        ] = "Regions<br><i>Foreign (light) over Total (opaque)"
 
         geo_types = ["Local", "Foreign"]
 
@@ -156,6 +156,10 @@ def _plot_linkages(
                         )
 
                         legends.add(region)
+
+                    # Show in hover text for each trace the region, value
+                    fig.update_traces(
+                        hovertemplate="%{y}<br>%{x:.4f}")
 
             # geo_type * links_type * regions
             counter.append(2 * 2 * len(data.index.unique(level=0)))


### PR DESCRIPTION
- There was an error with Backward linkages. The calculation (iomath.py)
was done making row sum even in the Backward cases where the sum are
column sum.

- In plots.py now the legend title is fixed and the hover data show values in .4f
  format correctly saying that reported values are total contribution
  (opacity=1 part of the chart) with the light one representing the
  foreing contribution.