### PR TITLE
Parse EORA SUT

### DIFF
--- a/mario/tools/parsers_id.py
+++ b/mario/tools/parsers_id.py
@@ -96,6 +96,8 @@ txt_parser_id = {
 
 eora = {
     _MASTER_INDEX["s"]: ["Industries"],
+    _MASTER_INDEX["a"]: ["Industries"],
+    _MASTER_INDEX["c"]: ["Commodities"],
     _MASTER_INDEX["f"]: ["Primary Inputs", "ImportsFrom"],
     _MASTER_INDEX["n"]: ["Final Demand", "ExportsTo"],
 }

--- a/mario/tools/parsersclass.py
+++ b/mario/tools/parsersclass.py
@@ -268,6 +268,7 @@ def parse_exiobase_3(
 def parse_eora(
     path,
     multi_region,
+    table,
     indeces=None,
     name_convention="full_name",
     aggregate_trade=True,
@@ -327,6 +328,9 @@ def parse_eora(
                 "For multi region Eora, the year and indeces path should be defined"
             )
 
+        if table == 'SUT':
+            raise NotImplemented("No handling of multiregional SUT from EORA is implemented yet")
+
         matrices, indeces, units = eora_multi_region(
             data_path=path, index_path=indeces, year=year, price="bp"
         )
@@ -339,12 +343,14 @@ def parse_eora(
 
     else:
         matrices, indeces, units = eora_single_region(
-            path=path, name_convention=name_convention, aggregate_trade=aggregate_trade
+            path=path, table=table, name_convention=name_convention, aggregate_trade=aggregate_trade
         )
+
+        
 
     return models[model](
         name=name,
-        table="IOT",
+        table=table,
         year=year,
         source="Eora website @ https://www.worldmrio.com/",
         init_by_parsers={"matrices": matrices, "_indeces": indeces, "units": units},


### PR DESCRIPTION
The code was previously not able to read properly an EORA Single region table if SUT. #56 

Not table must be passed to parse_eora so that the logics behind the handling of SUTs or IOT are properly called.

- On tableparser.py all the back-hand adjustements where made, adding if/else conditions based on table value
- On parser_id different master index for eora are called to read on the original txt
- On parsersclass table was added as a must-have input