### PR TITLE
parse_exiobase bug when passing Exiobase hybrid folder #66

### DIFF
--- a/mario/tools/parsersclass.py
+++ b/mario/tools/parsersclass.py
@@ -471,6 +471,9 @@ def hybrid_sut_exiobase(
         "The name of extensions are changed to avoid confusion of same satellite account category for different extensions. For example 'Food' in 'pack_use_waste_act' is changed to 'Food (pack_use_waste)' to avoid confusion with 'Food' in 'pack_sup_waste'"
     ]
 
+    if "year" in kwargs:
+        del kwargs["year"]
+        
     return models[model](
         name=name,
         table="SUT",


### PR DESCRIPTION
The issue was related to passing multiple year key argument to the function as the year for the hybrid exiobase is fixed (2011) and does not need to be passed as a user defined argument, so the value in the universal function had to be replaced with the original argument.