### PR TITLE
Fix requirements.txt to not use pandas 2+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas >= 1.3.3
+pandas >= 1.3.3,<2.0.0
 numpy >= 1.21.2
 xlsxwriter <= 1.3.7
 plotly >= 4.12.0


### PR DESCRIPTION
MARIO is not compatible with pandas 2.0.0+ (e.g. the use of pd.append, which should be rewritten to use pd.concat).

For now, just make sure a fresh install from the requirements.txt ensures it doesn't pull in the latest pandas.